### PR TITLE
Fix errors in calculation of mietzins-changes

### DIFF
--- a/mietrecht_ch/mietrecht_ch/doctype/rent/api.py
+++ b/mietrecht_ch/mietrecht_ch/doctype/rent/api.py
@@ -86,7 +86,7 @@ def __extra_room_validation__(payload):
     if extra_room is None:
         extra_room = 0
         return extra_room
-    return extra_room
+    return float(extra_room)
 
 
 def total_data(rent_pourcentage_change, final_rent_hypo, teuerung_inflation, rent_teuerung, cost_inflation, cost_value):
@@ -407,6 +407,9 @@ def __rent_validation__(payload):
 
 def __canton_validation__(payload):
     # Canton validation
-    canton = payload['canton']
-    data_empty_value(canton, 'canton')
-    data_type_validation_str(canton, 'canton')
+    input_type = payload['hypoReference']['inputType']
+    
+    if input_type == "search":
+        canton = payload['canton']
+        data_empty_value(canton, 'canton')
+        data_type_validation_str(canton, 'canton')


### PR DESCRIPTION
- Ich habe noch einen Fehler gefunden wenn beim zusätzlichen Raum etwas mitgegeben worden ist, weil das als string drin war und nicht als float/int.
- Die Validierung des Kantons findet nur statt, wenn `input_type == 'search'` ist.